### PR TITLE
fix: header中错误的mime类型

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -8,6 +8,7 @@ events {
 }
 
 http {
+  include    /etc/nginx/mime.types;
   access_log /dev/stdout;
   server_tokens off; # Hide nginx version in Server header & page footers
 


### PR DESCRIPTION
当CDN向请求添加nosniff时，错误的mime类型会导致浏览器拒绝加载js